### PR TITLE
Properly handle railway ways for the rail layer

### DIFF
--- a/profile/full.lua
+++ b/profile/full.lua
@@ -127,7 +127,9 @@ function process_way(way)
       way:add_string("rail", "detail")
 
     elseif way:has_tag("railway", "subway") or
-           way:has_tag("railway", "tram") then
+           way:has_tag("railway", "tram") or
+           way:has_tag("railway", "narrow_gauge") or
+           way:has_tag("railway", "light_rail") then
       way:set_target_layer("rail")
       way:set_approved_min(10)
       way:add_string("rail", "secondary")

--- a/profile/full.lua
+++ b/profile/full.lua
@@ -134,7 +134,7 @@ function process_way(way)
       way:set_approved_min(10)
       way:add_string("rail", "secondary")
 
-    else
+    elseif way:has_tag("railway", "rail") then
       way:set_target_layer("rail")
       way:set_approved_min(5)
       way:add_string("rail", "primary")

--- a/profile/full.lua
+++ b/profile/full.lua
@@ -104,7 +104,7 @@ function process_way(way)
       end
     end
 
-  elseif way:has_any_tag("railway", "rail", "subway", "tram") then
+  elseif way:has_any_tag("railway") then
     way:add_tag_as_integer("level")
 
     if way:has_tag("railway", "disused") or


### PR DESCRIPTION
This pull request fixes logic in the `full.lua` tile profile to not only consider `railway={rail,subway,tram}` but use all of the existing logic, with additions and fixes for more edge cases.

This results in the following change for https://www.openstreetmap.org/way/1081230203:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0f754672-d83e-4e69-b224-cf3a9fd8e3c3) | ![image](https://github.com/user-attachments/assets/bcf41d5c-ef87-4495-8dab-d112aa4c265d) |

Note that this needs an additional change in the MOTIS UI map style with `rail_old` suddenly working