### PR TITLE
Render unclassified as residential

### DIFF
--- a/client/style-background.js
+++ b/client/style-background.js
@@ -100,7 +100,7 @@ export const style = (map) => {
             "filter": [
               "!in",
               "highway",
-              "footway", "track", "steps", "cycleway", "path", "unclassified"
+              "footway", "track", "steps", "cycleway", "path"
             ],
             "layout": {
               "line-cap": "round",
@@ -115,7 +115,7 @@ export const style = (map) => {
                   ["trunk", "motorway_link"], 3.5,
                   ["primary", "secondary", "aeroway", "trunk_link"], 3,
                   ["primary_link", "secondary_link", "tertiary", "tertiary_link"], 1.75,
-                  "residential", 1.5,
+                  ["residential", "unclassified"], 1.5,
                 0.75],
                 ["interpolate", ["linear"], ["zoom"],
                   5,  ["+", ["*", ["var", "base"], 0.1], 1],
@@ -137,7 +137,7 @@ export const style = (map) => {
             "paint": {
               "line-color": "hsl(0, 0%, 98%)",
               "line-opacity": ["match", ["get", "highway"],
-                ["footway", "track", "steps", "cycleway", "path", "unclassified"], 0.66,
+                ["footway", "track", "steps", "cycleway", "path"], 0.66,
                 1],
               "line-width": [
                 "let",
@@ -146,7 +146,7 @@ export const style = (map) => {
                   ["trunk", "motorway_link"], 3.5,
                   ["primary", "secondary", "aeroway", "trunk_link"], 3,
                   ["primary_link", "secondary_link", "tertiary", "tertiary_link"], 1.75,
-                  "residential", 1.5,
+                  ["residential", "unclassified"], 1.5,
                 0.75],
                 ["interpolate", ["linear"], ["zoom"],
                   5,  ["*", ["var", "base"], 0.1],

--- a/client/style-default.js
+++ b/client/style-default.js
@@ -147,7 +147,7 @@ export const style = (map) => {
             "filter": [
               "!in",
               "highway",
-              "footway", "track", "steps", "cycleway", "path", "unclassified"
+              "footway", "track", "steps", "cycleway", "path"
             ],
             "layout": {
               "line-cap": "round",
@@ -162,7 +162,7 @@ export const style = (map) => {
                   ["trunk", "motorway_link"], 3.5,
                   ["primary", "secondary", "aeroway", "trunk_link"], 3,
                   ["primary_link", "secondary_link", "tertiary", "tertiary_link"], 1.75,
-                  "residential", 1.5,
+                  ["residential", "unclassified"], 1.5,
                 0.75],
                 ["interpolate", ["linear"], ["zoom"],
                   5,  ["+", ["*", ["var", "base"], 0.1], 1],
@@ -184,7 +184,7 @@ export const style = (map) => {
             "paint": {
               "line-color": "#ffffff",
               "line-opacity": ["match", ["get", "highway"],
-                ["footway", "track", "steps", "cycleway", "path", "unclassified"], 0.66,
+                ["footway", "track", "steps", "cycleway", "path"], 0.66,
                 1],
               "line-width": [
                 "let",
@@ -193,7 +193,7 @@ export const style = (map) => {
                   ["trunk", "motorway_link"], 3.5,
                   ["primary", "secondary", "aeroway", "trunk_link"], 3,
                   ["primary_link", "secondary_link", "tertiary", "tertiary_link"], 1.75,
-                  "residential", 1.5,
+                  ["residential", "unclassified"], 1.5,
                 0.75],
                 ["interpolate", ["linear"], ["zoom"],
                   5,  ["*", ["var", "base"], 0.1],


### PR DESCRIPTION
Hi, `highway=unclassified` is rendered similarly to a footway, but the definiton says that it's a "minor public road" ([wiki](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dunclassified)). The issue is visible ex. around Poznań Główny on [Aleja Króla Przemysła II](https://www.openstreetmap.org/way/376047785)
<details>

<summary>Comparison motis vs osm before change</summary>

<img width="876" height="888" alt="Zrzut ekranu 2026-03-7 o 11 51 40" src="https://github.com/user-attachments/assets/6bc43329-6451-4de8-a93c-f35a0834b441" />

<img width="873" height="925" alt="Zrzut ekranu 2026-03-7 o 11 51 50" src="https://github.com/user-attachments/assets/75dc0ef9-024e-45ad-92e8-1d5ea30b405d" />

</details>


This PR changes the rendering to be identical to residential streets. I don't have a local setup for this, but this seems like safe change 😉

Edit: the first screenshot is from transitous, I'm not entierly sure, that making a change here is the right solution 😅 Please confirm or direct me to the right solution 😅 