### PR TITLE
use gzip instead of deflate for tiles

### DIFF
--- a/include/tiles/get_tile.h
+++ b/include/tiles/get_tile.h
@@ -165,7 +165,7 @@ std::optional<std::string> get_tile(render_ctx const& ctx,
 
   if (ctx.compress_result_) {
     start<perf_task::GET_TILE_COMPRESS>(pc);
-    auto compressed = compress_deflate(rendered_tile);
+    auto compressed = compress_gzip(rendered_tile);
     stop<perf_task::GET_TILE_COMPRESS>(pc);
     pc.template append<perf_task::RESULT_SIZE>(compressed.size());
     return {std::move(compressed)};

--- a/include/tiles/util.h
+++ b/include/tiles/util.h
@@ -34,6 +34,7 @@ inline void t_log(fmt::format_string<Args...> fmt_str, Args&&... args) {
 }
 
 std::string compress_deflate(std::string const&);
+std::string compress_gzip(std::string const&);
 
 struct progress_tracker {
 #ifdef TILES_GLOBAL_PROGRESS_TRACKER

--- a/src/server.cc
+++ b/src/server.cc
@@ -195,7 +195,7 @@ int run_tiles_server(int argc, char const** argv) {
     }
 
     if (req[http::field::accept_encoding]  //
-            .find("deflate") == std::string_view::npos) {
+            .find("gzip") == std::string_view::npos) {
       res.result(http::status::not_implemented);
       return true;
     }
@@ -209,7 +209,7 @@ int run_tiles_server(int argc, char const** argv) {
 
     if (rendered_tile) {
       res.body() = std::move(*rendered_tile);
-      res.set(http::field::content_encoding, "deflate");
+      res.set(http::field::content_encoding, "gzip");
       res.result(http::status::ok);
     } else {
       res.result(http::status::no_content);

--- a/src/util.cc
+++ b/src/util.cc
@@ -33,7 +33,7 @@ std::string compress_gzip(std::string const& input) {
 
   utl::verify(error == Z_OK, "deflateInit2 failed");
 
-  auto out_size = compressBound(input.size()) + 32;
+  auto out_size = deflateBound(&zs, input.size());
   std::string buffer(out_size, '\0');
 
   zs.next_in = reinterpret_cast<uint8_t*>(const_cast<char*>(input.data()));

--- a/src/util.cc
+++ b/src/util.cc
@@ -22,6 +22,34 @@ std::string compress_deflate(std::string const& input) {
   return buffer;
 }
 
+std::string compress_gzip(std::string const& input) {
+  /**
+  Same as compress2, but with MAX_WBITS + 16 to indicate gzip header and trailer
+  */
+  z_stream zs{};
+
+  auto error = deflateInit2(&zs, Z_BEST_COMPRESSION, Z_DEFLATED, MAX_WBITS + 16,
+                            8, Z_DEFAULT_STRATEGY);
+
+  utl::verify(error == Z_OK, "deflateInit2 failed");
+
+  auto out_size = compressBound(input.size()) + 32;
+  std::string buffer(out_size, '\0');
+
+  zs.next_in = reinterpret_cast<uint8_t*>(const_cast<char*>(input.data()));
+  zs.avail_in = input.size();
+
+  zs.next_out = reinterpret_cast<uint8_t*>(buffer.data());
+  zs.avail_out = buffer.size();
+
+  error = deflate(&zs, Z_FINISH);
+  utl::verify(error == Z_STREAM_END, "deflate failed");
+
+  buffer.resize(zs.total_out);
+
+  deflateEnd(&zs);
+  return buffer;
+}
 struct regex_matcher::impl {
   explicit impl(std::string const& pattern) : regex_{pattern} {}
 

--- a/test/compress_test.cc
+++ b/test/compress_test.cc
@@ -17,14 +17,14 @@ std::string test_data() {
 }
 
 TEST(compress, deflate) {
-  auto test=test_data();
+  auto test = test_data();
 
   auto out = tiles::compress_deflate(test);
   EXPECT_FALSE(out.empty());
 }
 
 TEST(compress, gzip) {
-  auto test=test_data();
+  auto test = test_data();
 
   auto out = tiles::compress_gzip(test);
   EXPECT_FALSE(out.empty());

--- a/test/compress_test.cc
+++ b/test/compress_test.cc
@@ -5,7 +5,7 @@
 #include "tiles/bin_utils.h"
 #include "tiles/util.h"
 
-TEST_CASE("compress_deflate") {
+std::string test_data() {
   std::string test(1024ULL * 1024, '\0');
 
   std::mt19937 gen{42};
@@ -13,7 +13,19 @@ TEST_CASE("compress_deflate") {
   for (auto i = 0ULL; i < test.size(); i += sizeof(uint64_t)) {
     tiles::write(test.data(), i, dist(gen));
   }
+  return test;
+}
+
+TEST(compress, deflate) {
+  auto test=test_data();
 
   auto out = tiles::compress_deflate(test);
-  CHECK_FALSE(out.empty());
+  EXPECT_FALSE(out.empty());
+}
+
+TEST(compress, gzip) {
+  auto test=test_data();
+
+  auto out = tiles::compress_gzip(test);
+  EXPECT_FALSE(out.empty());
 }


### PR DESCRIPTION
fixes #18

This is a simple fix, but it does break the compatibility with existing database files.
